### PR TITLE
ref(*): remove need for supplying installation ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,21 +148,16 @@ This gateway can enable a feature that converts PRs to Check Suite requests. Cur
 To disable this feature, set the environment variable `CHECK_SUITE_ON_PR=false` on the deployment for the server.
 This can also be done by setting `github.checkSuiteOnPR` to `false` in the chart's `values.yaml`.
 
-To forward a pull request (`pull_request`) to a check suite run, you will need to set two additional configurations for the gateway.
+To forward a pull request (`pull_request`) to a check suite run, you will need to provide the ID for your GitHub Brigade App instance.
 (Here also set at the chart-level via `values.yaml`):
 
 ```
 github:
 ...
   appID: APP_ID
-  installationID: INSTALLATION_ID
 ```
 
-`APP_ID` is the ID for your GitHub Brigade App instance, and `INSTALLATION_ID` is the installation ID for your GitHub Brigade App.
-
-These are provided after the GitHub App Installation on GitHub (see 1. Create a GitHub App).
-* For the `APP_ID` see `https://github.com/settings/apps/your-app-name`
-* For the `INSTALLATION_ID` go to `https://github.com/settings/apps/your-app-name/installations`. Click on the desired installation to get the id within the URL: `https://github.com/settings/installations/1234567`
+This value is provided after the GitHub App is created on GitHub (see 1. Create a GitHub App). To find this value after creation, visit `https://github.com/settings/apps/your-app-name`.
 
 When these parameters are set, incoming pull requests will also trigger `check_suite:created` events.
 

--- a/charts/brigade-github-app/templates/deployment.yaml
+++ b/charts/brigade-github-app/templates/deployment.yaml
@@ -36,8 +36,6 @@ spec:
             value: "/etc/brigade-github-app/key.pem"
           - name: APP_ID
             value: "{{ .Values.github.appID }}"
-          - name: INSTALLATION_ID
-            value: "{{ .Values.github.installationID }}"
           - name: CHECK_SUITE_ON_PR
             value: "{{ .Values.github.checkSuiteOnPR }}"
         volumeMounts:

--- a/charts/brigade-github-app/values.yaml
+++ b/charts/brigade-github-app/values.yaml
@@ -45,9 +45,6 @@ github:
   # This represents the unique ID for a GitHub App
   # The value can be retrieved from the main App page or any inbound webhook payloads
   appID:
-  # This represents the installation for the GitHub App
-  # The value can be retrieved from inbound webhook payloads for the given App
-  installationID:
   # Trigger a Check Suite on Pull Requests
   # This will need to be set to true to enable running Check Suites on PRs originating from forks
   checkSuiteOnPR: true

--- a/cmd/github-gateway/server.go
+++ b/cmd/github-gateway/server.go
@@ -96,7 +96,6 @@ func main() {
 	ghOpts := webhook.GithubOpts{
 		CheckSuiteOnPR: envOrBool("CHECK_SUITE_ON_PR", true),
 		AppID:          envOrInt("APP_ID", 0),
-		InstallationID: envOrInt("INSTALLATION_ID", 0),
 	}
 
 	clientset, err := kube.GetClient(master, kubeconfig)

--- a/pkg/webhook/github.go
+++ b/pkg/webhook/github.go
@@ -40,7 +40,6 @@ type GithubOpts struct {
 	// CheckSuiteOnPR will trigger a check suite run for new PRs that pass the security params.
 	CheckSuiteOnPR bool
 	AppID          int
-	InstallationID int
 }
 
 type fileGetter func(commit, path string, proj *brigade.Project) ([]byte, error)
@@ -341,7 +340,7 @@ func (s *githubHook) prToCheckSuite(c *gin.Context, pre *github.PullRequestEvent
 	ref := fmt.Sprintf("refs/pull/%d/head", pre.PullRequest.GetNumber())
 	sha := pre.PullRequest.Head.GetSHA()
 	appID := s.opts.AppID
-	instID := s.opts.InstallationID
+	instID := pre.Installation.GetID()
 
 	if appID == 0 || instID == 0 {
 		log.Printf("App ID and Installation ID must both be set. App: %d, Installation: %d", appID, instID)


### PR DESCRIPTION
Rather, grab it from the incoming webhook payload.

This enables using the same GitHub App across orgs/installations.

Closes https://github.com/Azure/brigade-github-app/issues/19